### PR TITLE
fix(security): harden enquiries and tour extras

### DIFF
--- a/inc/Classes/Tour/Tour.php
+++ b/inc/Classes/Tour/Tour.php
@@ -4654,9 +4654,9 @@ class Tour {
 		$tour_extra_title_arr = [];
 		$tour_extra_meta      = ! empty( $meta['tour-extra'] ) ? $meta['tour-extra'] : '';
 		if ( ! empty( $tour_extra_meta ) ) {
-			$tf_tour_extra = !empty($_POST['tour_extra']) ? sanitize_text_field($_POST['tour_extra']) : '';
+			$tf_tour_extra = !empty($_POST['tour_extra']) ? sanitize_text_field( wp_unslash( $_POST['tour_extra'] ) ) : '';
 			$tours_extra         = !empty($tf_tour_extra) ? explode( ',', $tf_tour_extra ) : [];
-			$tf_tour_extra_quantity = !empty($_POST['tour_extra_quantity']) ? sanitize_text_field($_POST['tour_extra_quantity']) : '';
+			$tf_tour_extra_quantity = !empty($_POST['tour_extra_quantity']) ? sanitize_text_field( wp_unslash( $_POST['tour_extra_quantity'] ) ) : '';
 			$tour_extra_quantity = !empty($tf_tour_extra_quantity) ? explode( ',', $tf_tour_extra_quantity ) : [];
 
 			if(!empty($tours_extra)){
@@ -4672,10 +4672,11 @@ class Tour {
 						}
 					} else if ( $tour_extra_pricetype == "quantity" ) {
 						if ( ! empty( $tour_extra_meta[ $extra ]['title'] ) && ! empty( $tour_extra_meta[ $extra ]['price'] ) ) {
-							$tour_extra_total       += $tour_extra_meta[ $extra ]['price'] * $tour_extra_quantity[ $extra_key ];
+							$extra_quantity          = isset( $tour_extra_quantity[ $extra_key ] ) ? max( 0, intval( $tour_extra_quantity[ $extra_key ] ) ) : 0;
+							$tour_extra_total       += $tour_extra_meta[ $extra ]['price'] * $extra_quantity;
 							$tour_extra_title_arr[] = array(
-								'title' => $tour_extra_meta[ $extra ]['title'] . " x " . $tour_extra_quantity[ $extra_key ],
-								'price' => $tour_extra_meta[ $extra ]['price'] * $tour_extra_quantity[ $extra_key ]
+								'title' => $tour_extra_meta[ $extra ]['title'] . " x " . $extra_quantity,
+								'price' => $tour_extra_meta[ $extra ]['price'] * $extra_quantity
 							);
 						}
 					} else {
@@ -4688,6 +4689,7 @@ class Tour {
 						}
 					}
 				}
+				$tour_extra_total = max( 0, $tour_extra_total );
 			}
 		}
 

--- a/inc/Core/Enquiry.php
+++ b/inc/Core/Enquiry.php
@@ -709,10 +709,167 @@ abstract class Enquiry {
 			return 'Invalid date';
 		}
 	}
-	
-	
-	
-	public function enquiry_table_data( $post_type = '', $post_id = '', $status = '', $offset = 0, $per_page = 0 ) {
+
+	protected function tf_enquiry_post_type_capabilities() {
+		return array(
+			'tf_hotel'     => 'edit_tf_hotels',
+			'tf_tours'     => 'edit_tf_tourss',
+			'tf_apartment' => 'edit_tf_apartments',
+		);
+	}
+
+	protected function tf_enquiry_view_permission_keys() {
+		return array(
+			'tf_hotel'     => 'view_hotel_enquiry',
+			'tf_tours'     => 'view_tour_enquiry',
+			'tf_apartment' => 'view_apartment_enquiry',
+		);
+	}
+
+	protected function tf_enquiry_status_filters() {
+		return array( 'read', 'unread', 'replied', 'responded', 'not-replied', 'not-responded' );
+	}
+
+	protected function tf_get_requested_enquiry_post_type() {
+		$post_type = isset( $_POST['post_type'] ) ? sanitize_key( wp_unslash( $_POST['post_type'] ) ) : '';
+
+		return array_key_exists( $post_type, $this->tf_enquiry_post_type_capabilities() ) ? $post_type : '';
+	}
+
+	protected function tf_get_requested_enquiry_filter() {
+		$filter = isset( $_POST['filter'] ) ? sanitize_key( wp_unslash( $_POST['filter'] ) ) : '';
+
+		return in_array( $filter, $this->tf_enquiry_status_filters(), true ) ? $filter : '';
+	}
+
+	protected function tf_get_user_permission_list( $permission_group ) {
+		$user_permission = Helper::tf_data_types( Helper::tfopt( 'tf_user_permission' ) );
+
+		return isset( $user_permission[ $permission_group ] ) && is_array( $user_permission[ $permission_group ] ) ? $user_permission[ $permission_group ] : array();
+	}
+
+	protected function tf_current_user_has_role( $role ) {
+		$user = wp_get_current_user();
+
+		return in_array( $role, (array) $user->roles, true );
+	}
+
+	protected function tf_role_permission_allows( $permission_group, $permission ) {
+		$permissions = $this->tf_get_user_permission_list( $permission_group );
+
+		return empty( $permissions ) || in_array( $permission, $permissions, true );
+	}
+
+	protected function tf_current_user_can_manage_enquiry_post_type( $post_type ) {
+		$capabilities = $this->tf_enquiry_post_type_capabilities();
+		if ( empty( $post_type ) || ! isset( $capabilities[ $post_type ] ) ) {
+			return false;
+		}
+
+		if ( current_user_can( 'manage_options' ) ) {
+			return true;
+		}
+
+		$permission_keys = $this->tf_enquiry_view_permission_keys();
+		$permission_key  = $permission_keys[ $post_type ];
+
+		if ( $this->tf_current_user_has_role( 'tf_manager' ) ) {
+			return current_user_can( 'tf_manager_options' )
+				&& current_user_can( $capabilities[ $post_type ] )
+				&& $this->tf_role_permission_allows( 'manager_can_manage', $permission_key );
+		}
+
+		if ( $this->tf_current_user_has_role( 'tf_vendor' ) ) {
+			return current_user_can( 'tf_vendor_options' )
+				&& current_user_can( $capabilities[ $post_type ] )
+				&& $this->tf_role_permission_allows( 'vendor_can_manage', $permission_key );
+		}
+
+		return current_user_can( $capabilities[ $post_type ] );
+	}
+
+	protected function tf_current_user_can_manage_all_enquiries( $post_type ) {
+		if ( current_user_can( 'manage_options' ) ) {
+			return true;
+		}
+
+		return $this->tf_current_user_has_role( 'tf_manager' )
+			&& current_user_can( 'tf_manager_options' )
+			&& $this->tf_current_user_can_manage_enquiry_post_type( $post_type );
+	}
+
+	protected function tf_current_user_can_access_enquiry_post( $post_type, $post_id = 0 ) {
+		if ( ! $this->tf_current_user_can_manage_enquiry_post_type( $post_type ) ) {
+			return false;
+		}
+
+		if ( $this->tf_current_user_can_manage_all_enquiries( $post_type ) ) {
+			return true;
+		}
+
+		if ( ! $this->tf_current_user_has_role( 'tf_vendor' ) ) {
+			return true;
+		}
+
+		return empty( $post_id ) || absint( get_post_field( 'post_author', $post_id ) ) === get_current_user_id();
+	}
+
+	protected function tf_current_user_can_access_enquiry( $enquiry ) {
+		if ( empty( $enquiry['post_type'] ) ) {
+			return false;
+		}
+
+		$post_type = sanitize_key( $enquiry['post_type'] );
+		$post_id   = ! empty( $enquiry['post_id'] ) ? absint( $enquiry['post_id'] ) : 0;
+
+		if ( ! $this->tf_current_user_can_access_enquiry_post( $post_type, $post_id ) ) {
+			return false;
+		}
+
+		if ( $this->tf_current_user_can_manage_all_enquiries( $post_type ) ) {
+			return true;
+		}
+
+		if ( $this->tf_current_user_has_role( 'tf_vendor' ) ) {
+			$author_id = ! empty( $enquiry['author_id'] ) ? absint( $enquiry['author_id'] ) : 0;
+
+			return $author_id === get_current_user_id() || absint( get_post_field( 'post_author', $post_id ) ) === get_current_user_id();
+		}
+
+		return true;
+	}
+
+	protected function tf_current_user_can_reply_to_enquiry( $enquiry ) {
+		if ( ! $this->tf_current_user_can_access_enquiry( $enquiry ) ) {
+			return false;
+		}
+
+		if ( current_user_can( 'manage_options' ) ) {
+			return true;
+		}
+
+		if ( $this->tf_current_user_has_role( 'tf_manager' ) ) {
+			return $this->tf_role_permission_allows( 'manager_can_manage', 'enquiry_email' );
+		}
+
+		if ( $this->tf_current_user_has_role( 'tf_vendor' ) ) {
+			return $this->tf_role_permission_allows( 'vendor_can_manage', 'enquiry_email' );
+		}
+
+		return false;
+	}
+
+	protected function tf_send_enquiry_json_error( $message, $status_code = 403 ) {
+		wp_send_json(
+			array(
+				'status' => 'error',
+				'msg'    => $message,
+			),
+			$status_code
+		);
+	}
+
+	public function enquiry_table_data( $post_type = '', $post_id = '', $status = '', $offset = 0, $per_page = 0, $author_id = 0 ) {
 
 		 global $wpdb;
 		 $enquiry_data = array();
@@ -723,6 +880,11 @@ abstract class Enquiry {
 		if ( $post_id ) {
 			$where[]  = 'post_id = %d';
 			$values[] = absint( $post_id );
+		}
+
+		if ( $author_id ) {
+			$where[]  = 'author_id = %d';
+			$values[] = absint( $author_id );
 		}
 		if( !empty($status) ) {
 			$status = sanitize_key( $status );
@@ -949,6 +1111,23 @@ abstract class Enquiry {
 
 		global $wpdb;
 
+		foreach ( $enquiry_ids as $enquiry_id ) {
+			$enquiry = $wpdb->get_row(
+				$wpdb->prepare(
+					"SELECT * FROM {$wpdb->prefix}tf_enquiry_data WHERE id = %d",
+					$enquiry_id
+				),
+				ARRAY_A
+			);
+
+			if ( empty( $enquiry ) || ! $this->tf_current_user_can_access_enquiry( $enquiry ) ) {
+				$response['status'] = 'error';
+				$response['msg']    = esc_html__( 'You do not have permission to perform this action.', 'tourfic' );
+				echo wp_json_encode( $response );
+				wp_die();
+			}
+		}
+
 		if ( 'trash' == $bulk_action ) {
 			foreach ( $enquiry_ids as $enquiry_id ) {
 				$wpdb->query(
@@ -973,11 +1152,21 @@ abstract class Enquiry {
 
 	function tf_enquiry_filter_post_callback() {
 
-		$post_id = isset( $_POST['post_id'] ) ? sanitize_text_field( $_POST['post_id'] ) : '';
-		$post_type = isset( $_POST['post_type'] ) ? sanitize_text_field( $_POST['post_type'] ) : '';
-		$filter = isset( $_POST['filter'] ) ? sanitize_text_field ( $_POST['filter'] ) : '';
+		if ( ! check_ajax_referer( 'updates', '_ajax_nonce', false ) ) {
+			$this->tf_send_enquiry_json_error( esc_html__( 'Security error! Reload the page and try again.', 'tourfic' ), 403 );
+		}
 
-		$enquiry_data = $this->enquiry_table_data( $post_type, $post_id, $filter );
+		$post_id   = isset( $_POST['post_id'] ) ? absint( wp_unslash( $_POST['post_id'] ) ) : 0;
+		$post_type = $this->tf_get_requested_enquiry_post_type();
+		$filter    = $this->tf_get_requested_enquiry_filter();
+
+		if ( empty( $post_type ) || ! $this->tf_current_user_can_access_enquiry_post( $post_type, $post_id ) ) {
+			$this->tf_send_enquiry_json_error( esc_html__( 'You do not have permission to perform this action.', 'tourfic' ), 403 );
+		}
+
+		$author_id = $this->tf_current_user_can_manage_all_enquiries( $post_type ) ? 0 : get_current_user_id();
+
+		$enquiry_data = $this->enquiry_table_data( $post_type, $post_id, $filter, 0, 0, $author_id );
 
 		$this->enquiry_details_list( $enquiry_data );
 
@@ -993,26 +1182,54 @@ abstract class Enquiry {
 		global $current_user;
 		$reply_data = array();
 
-		if ( isset( $_POST['enquiry_id'] ) ) {
-			$enquiry_id = absint( wp_unslash( $_POST['enquiry_id'] ) ); // sanitize as integer
-
-			$reply_data = $wpdb->get_results( 
-				$wpdb->prepare(
-					"SELECT reply_data FROM {$wpdb->prefix}tf_enquiry_data WHERE id = %d",
-					$enquiry_id
-				)
-			);
+		if ( ! check_ajax_referer( 'updates', '_ajax_nonce', false ) ) {
+			$this->tf_send_enquiry_json_error( esc_html__( 'Security error! Reload the page and try again.', 'tourfic' ), 403 );
 		}
 
-		$reply_data = json_decode( $reply_data[0]->reply_data, true );
+		$enquiry_id = isset( $_POST['enquiry_id'] ) ? absint( wp_unslash( $_POST['enquiry_id'] ) ) : 0;
+		$post_id    = isset( $_POST['post_id'] ) ? absint( wp_unslash( $_POST['post_id'] ) ) : 0;
 
-		check_ajax_referer('updates', '_ajax_nonce');
+		if ( empty( $enquiry_id ) ) {
+			$response['status'] = 'error';
+			$response['msg']    = esc_html__( 'Invalid enquiry selected.', 'tourfic' );
+			echo wp_json_encode( $response );
+			wp_die();
+		}
 
-		$reply_mail = isset( $_POST['reply_mail'] ) ? sanitize_text_field( $_POST['reply_mail'] ) : '';
-		$reply_message = isset( $_POST['reply_message'] ) ? wp_kses_post( $_POST['reply_message'] ) : '';
-		$post_id = isset( $_POST['post_id'] ) ? sanitize_text_field( $_POST['post_id'] ) : '';
-		$post_type = !empty( $post_id ) ? get_post_type( $post_id ) : '';
-		$enquiry_id = isset( $_POST['enquiry_id'] ) ? sanitize_text_field( $_POST['enquiry_id'] ) : '';
+		$enquiry = $wpdb->get_row(
+			$wpdb->prepare(
+				"SELECT * FROM {$wpdb->prefix}tf_enquiry_data WHERE id = %d",
+				$enquiry_id
+			),
+			ARRAY_A
+		);
+
+		if ( empty( $enquiry ) ) {
+			$response['status'] = 'error';
+			$response['msg']    = esc_html__( 'Enquiry not found.', 'tourfic' );
+			echo wp_json_encode( $response );
+			wp_die();
+		}
+
+		if ( ! empty( $post_id ) && absint( $enquiry['post_id'] ) !== $post_id ) {
+			$response['status'] = 'error';
+			$response['msg']    = esc_html__( 'Invalid enquiry selected.', 'tourfic' );
+			echo wp_json_encode( $response );
+			wp_die();
+		}
+
+		$post_id = absint( $enquiry['post_id'] );
+
+		if ( ! $this->tf_current_user_can_reply_to_enquiry( $enquiry ) ) {
+			$this->tf_send_enquiry_json_error( esc_html__( 'You do not have permission to perform this action.', 'tourfic' ), 403 );
+		}
+
+		$decoded_reply_data = ! empty( $enquiry['reply_data'] ) ? json_decode( $enquiry['reply_data'], true ) : array();
+		$reply_data         = is_array( $decoded_reply_data ) ? $decoded_reply_data : array();
+
+		$reply_mail    = isset( $_POST['reply_mail'] ) ? sanitize_email( wp_unslash( $_POST['reply_mail'] ) ) : '';
+		$reply_message = isset( $_POST['reply_message'] ) ? wp_kses_post( wp_unslash( $_POST['reply_message'] ) ) : '';
+		$post_type     = !empty( $post_id ) ? get_post_type( $post_id ) : '';
 
 		$connection_type = !empty( Helper::tfopt("tf-email-piping")["connection_type"]) ? Helper::tfopt("tf-email-piping")["connection_type"] : 'imap';
 		$connection_mail = $enquiry_mail_setting = '';
@@ -1045,13 +1262,13 @@ abstract class Enquiry {
 		if( empty( $reply_message ) ) {
 			$response['status'] = 'error';
 			$response['msg']    = esc_html__( 'Reply Message is Required!', 'tourfic' );
-
 		}
 
-		if ( ! current_user_can( 'manage_options' ) ) {
+		if ( ! is_email( $reply_mail ) ) {
 			$response['status'] = 'error';
-			$response['msg']    = esc_html__( 'You do not have permission to perform this action.', 'tourfic' );
-			$response['msg']    = esc_html__( 'You do not have permission to perform this action.', 'tourfic' );
+			$response['msg']    = esc_html__( 'Invalid reply email address.', 'tourfic' );
+			echo wp_json_encode( $response );
+			wp_die();
 		}
 
 		if( !empty( $reply_mail ) && !empty( $reply_message ) ) {
@@ -1116,19 +1333,24 @@ abstract class Enquiry {
 	}
 
 	function tf_enquiry_filter_mail_callback() {
-		$filter = isset( $_POST['filter'] ) ? sanitize_text_field( $_POST['filter'] )  : '';
-		$post_type = isset( $_POST['post_type'] ) ? sanitize_text_field( $_POST['post_type'] ) : '';
-		$post_id = isset( $_POST['post_id'] ) ? sanitize_text_field( $_POST['post_id'] ) : '';
+		if ( ! check_ajax_referer( 'updates', '_ajax_nonce', false ) ) {
+			$this->tf_send_enquiry_json_error( esc_html__( 'Security error! Reload the page and try again.', 'tourfic' ), 403 );
+		}
 
-		$enquiry_data = $this->enquiry_table_data( $post_type, $post_id, $filter );
-		$total_data = !empty(count( $enquiry_data )) ? count( $enquiry_data ) : 0;
-		$per_page = 20;
+		$filter    = $this->tf_get_requested_enquiry_filter();
+		$post_type = $this->tf_get_requested_enquiry_post_type();
+		$post_id   = isset( $_POST['post_id'] ) ? absint( wp_unslash( $_POST['post_id'] ) ) : 0;
+
+		if ( empty( $post_type ) || ! $this->tf_current_user_can_access_enquiry_post( $post_type, $post_id ) ) {
+			$this->tf_send_enquiry_json_error( esc_html__( 'You do not have permission to perform this action.', 'tourfic' ), 403 );
+		}
+
+		$author_id    = $this->tf_current_user_can_manage_all_enquiries( $post_type ) ? 0 : get_current_user_id();
+		$enquiry_data = $this->enquiry_table_data( $post_type, $post_id, $filter, 0, 0, $author_id );
 
 		$this->enquiry_details_list( $enquiry_data );
 
 		wp_reset_postdata();
-
-		wp_die();
 
 		wp_die();
 	}

--- a/inc/functions/woocommerce/wc-tour.php
+++ b/inc/functions/woocommerce/wc-tour.php
@@ -415,6 +415,7 @@ function tf_tours_booking_function() {
 
 	// Tour extra
 	$tour_extra_total = 0;
+	$tour_extra_title = '';
 	$tour_extra_title_arr = [];
 	
 	$tour_extra_meta = ! empty( $meta['tour-extra'] ) ? $meta['tour-extra'] : '';
@@ -422,7 +423,7 @@ function tf_tours_booking_function() {
 		$tf_tours_extra = isset( $_POST['tour_extra'] ) && ! empty( $_POST['tour_extra'] ) ?  sanitize_text_field(wp_unslash( $_POST['tour_extra'] )) : [];
 		$tours_extra = ! empty( $tf_tours_extra ) ? explode( ',', $tf_tours_extra ) : [];
 
-		$tf_tour_extra_quantity = isset( $_POST['tour_extra_quantity'] ) && ! empty( $_POST['tour_extra_quantity'] ) ? sanitize_text_field( wp_unslash( $_POST['tour_extra_quantity'] ) ) : [];
+		$tf_tour_extra_quantity = isset( $_POST['tour_extra_quantity'] ) && ! empty( $_POST['tour_extra_quantity'] ) ? sanitize_text_field( wp_unslash( $_POST['tour_extra_quantity'] ) ) : '';
 		$tour_extra_quantity = ! empty( $tf_tour_extra_quantity ) ? explode( ',', $tf_tour_extra_quantity ) : [];
 
 		foreach($tours_extra as $extra_key => $extra){
@@ -434,8 +435,9 @@ function tf_tours_booking_function() {
 				}
 			} else if($tour_extra_pricetype == "quantity") {
 				if(!empty($tour_extra_meta[$extra]['title']) && !empty($tour_extra_meta[$extra]['price'])){
-					$tour_extra_total += $tour_extra_meta[$extra]['price'] * $tour_extra_quantity[$extra_key];
-					$tour_extra_title_arr[] = $tour_extra_meta[$extra]['title']." (Per Unit: ".wc_price($tour_extra_meta[$extra]['price']).'*'.$tour_extra_quantity[$extra_key]."=".wc_price($tour_extra_meta[$extra]['price']*$tour_extra_quantity[$extra_key]).")";
+					$extra_quantity = isset( $tour_extra_quantity[$extra_key] ) ? max( 0, intval( $tour_extra_quantity[$extra_key] ) ) : 0;
+					$tour_extra_total += $tour_extra_meta[$extra]['price'] * $extra_quantity;
+					$tour_extra_title_arr[] = $tour_extra_meta[$extra]['title']." (Per Unit: ".wc_price($tour_extra_meta[$extra]['price']).'*'.$extra_quantity."=".wc_price($tour_extra_meta[$extra]['price']*$extra_quantity).")";
 				}
 			}else{
 				if(!empty($tour_extra_meta[$extra]['price']) && !empty($tour_extra_meta[$extra]['title'])){
@@ -444,9 +446,11 @@ function tf_tours_booking_function() {
 				}
 			}
 		}
-	}
 
-	$tour_extra_title = ! empty( $tour_extra_title_arr ) ? implode(",",$tour_extra_title_arr) : '';
+		$tour_extra_total = max( 0, $tour_extra_total );
+
+		$tour_extra_title = ! empty( $tour_extra_title_arr ) ? implode(",",$tour_extra_title_arr) : '';
+	}
 
 	/**
 	 * People 0 number validation

--- a/tests/security/wp-review-enquiry-tour-extra-security.php
+++ b/tests/security/wp-review-enquiry-tour-extra-security.php
@@ -1,0 +1,170 @@
+<?php
+/**
+ * Static regression checks for WordPress review enquiry and tour-extra findings.
+ *
+ * Run from the Tourfic Free plugin root:
+ * php tests/security/wp-review-enquiry-tour-extra-security.php
+ */
+
+$root = dirname( __DIR__, 2 );
+
+$files = array(
+	'enquiry'  => $root . '/inc/Core/Enquiry.php',
+	'wc_tour'  => $root . '/inc/functions/woocommerce/wc-tour.php',
+	'tour_cls' => $root . '/inc/Classes/Tour/Tour.php',
+);
+
+foreach ( $files as $label => $file ) {
+	if ( ! is_readable( $file ) ) {
+		fwrite( STDERR, "Missing fixture {$label}: {$file}\n" );
+		exit( 1 );
+	}
+}
+
+function tf_wp_review_security_assert( $condition, $message ) {
+	if ( ! $condition ) {
+		fwrite( STDERR, "FAIL: {$message}\n" );
+		exit( 1 );
+	}
+}
+
+function tf_wp_review_security_file( $file ) {
+	return file_get_contents( $file );
+}
+
+function tf_wp_review_security_function_body( $source, $function ) {
+	$matched = preg_match( '/function\s+' . preg_quote( $function, '/' ) . '\s*\(/', $source, $matches, PREG_OFFSET_CAPTURE );
+	tf_wp_review_security_assert( 1 === $matched, "Function {$function} not found." );
+
+	$offset = $matches[0][1];
+	$brace  = strpos( $source, '{', $offset );
+	tf_wp_review_security_assert( false !== $brace, "Function {$function} has no body." );
+
+	$depth  = 0;
+	$length = strlen( $source );
+	for ( $i = $brace; $i < $length; $i++ ) {
+		if ( '{' === $source[ $i ] ) {
+			$depth++;
+		} elseif ( '}' === $source[ $i ] ) {
+			$depth--;
+			if ( 0 === $depth ) {
+				return substr( $source, $brace, $i - $brace + 1 );
+			}
+		}
+	}
+
+	tf_wp_review_security_assert( false, "Function {$function} body is not balanced." );
+}
+
+function tf_wp_review_security_assert_order( $body, $first, $second, $message ) {
+	$first_offset  = strpos( $body, $first );
+	$second_offset = strpos( $body, $second );
+
+	tf_wp_review_security_assert( false !== $first_offset, "Missing first marker for order check: {$first}" );
+	tf_wp_review_security_assert( false !== $second_offset, "Missing second marker for order check: {$second}" );
+	tf_wp_review_security_assert( $first_offset < $second_offset, $message );
+}
+
+$enquiry_source = tf_wp_review_security_file( $files['enquiry'] );
+$wc_tour_source = tf_wp_review_security_file( $files['wc_tour'] );
+$tour_cls_source = tf_wp_review_security_file( $files['tour_cls'] );
+
+foreach ( array( 'tf_enquiry_filter_post_callback', 'tf_enquiry_filter_mail_callback' ) as $callback ) {
+	$body = tf_wp_review_security_function_body( $enquiry_source, $callback );
+
+	tf_wp_review_security_assert_order(
+		$body,
+		"check_ajax_referer( 'updates', '_ajax_nonce', false )",
+		'enquiry_table_data',
+		"{$callback} must verify nonce before reading enquiry data."
+	);
+	tf_wp_review_security_assert_order(
+		$body,
+		'tf_current_user_can_access_enquiry_post',
+		'enquiry_table_data',
+		"{$callback} must authorize before reading enquiry data."
+	);
+	tf_wp_review_security_assert(
+		false !== strpos( $body, 'tf_current_user_can_manage_all_enquiries' ),
+		"{$callback} must scope non-manager users to their own enquiries."
+	);
+}
+
+$reply_body = tf_wp_review_security_function_body( $enquiry_source, 'tf_enquiry_reply_email_callback' );
+tf_wp_review_security_assert_order(
+	$reply_body,
+	"check_ajax_referer( 'updates', '_ajax_nonce', false )",
+	"SELECT * FROM {\$wpdb->prefix}tf_enquiry_data WHERE id = %d",
+	'Reply callback must verify nonce before reading reply data.'
+);
+tf_wp_review_security_assert_order(
+	$reply_body,
+	'tf_current_user_can_reply_to_enquiry',
+	'wp_mail(',
+	'Reply callback must authorize before sending mail.'
+);
+tf_wp_review_security_assert_order(
+	$reply_body,
+	'tf_current_user_can_reply_to_enquiry',
+	'UPDATE {$wpdb->prefix}tf_enquiry_data SET enquiry_status',
+	'Reply callback must authorize before updating enquiry data.'
+);
+tf_wp_review_security_assert(
+	false === strpos( $reply_body, "if ( ! current_user_can( 'manage_options' ) )" ),
+	'Reply callback must not keep the old non-terminal manage_options gate.'
+);
+tf_wp_review_security_assert(
+	false !== strpos( $reply_body, 'is_email( $reply_mail )' ),
+	'Reply callback must validate the recipient email after sanitizing it.'
+);
+
+$bulk_body = tf_wp_review_security_function_body( $enquiry_source, 'tf_enquiry_bulk_action_callback' );
+tf_wp_review_security_assert_order(
+	$bulk_body,
+	'tf_current_user_can_access_enquiry',
+	"DELETE FROM {\$wpdb->prefix}tf_enquiry_data",
+	'Bulk delete must authorize each enquiry before deleting.'
+);
+tf_wp_review_security_assert_order(
+	$bulk_body,
+	'tf_current_user_can_access_enquiry',
+	"UPDATE {\$wpdb->prefix}tf_enquiry_data SET enquiry_status",
+	'Bulk status changes must authorize each enquiry before updating.'
+);
+
+$wc_tour_booking = tf_wp_review_security_function_body( $wc_tour_source, 'tf_tours_booking_function' );
+tf_wp_review_security_assert(
+	false !== strpos( $wc_tour_source, "wp_ajax_nopriv_tf_tours_booking" ),
+	'Tour booking must remain publicly reachable for frontend bookings.'
+);
+tf_wp_review_security_assert(
+	false !== strpos( $wc_tour_booking, "\$tour_extra_title = '';" ),
+	'WooCommerce tour booking must keep tour_extra_title initialized for tours without extras.'
+);
+tf_wp_review_security_assert(
+	false !== strpos( $wc_tour_booking, 'max( 0, intval( $tour_extra_quantity[$extra_key] ) )' ),
+	'WooCommerce tour booking must normalize quantity-priced extras to non-negative integers.'
+);
+tf_wp_review_security_assert(
+	false !== strpos( $wc_tour_booking, '$tour_extra_total = max( 0, $tour_extra_total );' ),
+	'WooCommerce tour booking must floor computed tour extra total before storage.'
+);
+tf_wp_review_security_assert(
+	false === strpos( $wc_tour_booking, '* $tour_extra_quantity[$extra_key]' ),
+	'WooCommerce tour booking must not multiply directly by client-supplied extra quantity.'
+);
+
+tf_wp_review_security_assert(
+	false !== strpos( $tour_cls_source, 'max( 0, intval( $tour_extra_quantity[ $extra_key ] ) )' ),
+	'Tour details pricing must normalize quantity-priced extras to non-negative integers.'
+);
+tf_wp_review_security_assert(
+	false !== strpos( $tour_cls_source, '$tour_extra_total = max( 0, $tour_extra_total );' ),
+	'Tour details pricing must floor computed tour extra total.'
+);
+tf_wp_review_security_assert(
+	false === strpos( $tour_cls_source, '* $tour_extra_quantity[ $extra_key ]' ),
+	'Tour details pricing must not multiply directly by client-supplied extra quantity.'
+);
+
+echo "WordPress review enquiry and tour-extra security regression checks passed.\n";


### PR DESCRIPTION
Stop unauthorized enquiry AJAX reads and replies before customer data, mail delivery, or enquiry status updates can be reached.

Clamp quantity-priced tour extras to non-negative values so frontend booking requests cannot reduce cart or offline booking totals.

Add focused regression coverage for the WordPress review findings.